### PR TITLE
Alternative of `pecrant cd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Usage: pecrant <command>
   up      Start the selected vagrant machine
   halt    Stop the selected vagrant machine
   ssh     Connect to machine via SSH
-  list    Show vagrant environments for this user
+  list    Show vagrant environments for this user (and output directory)
   help    Show this message
 ```
 
@@ -43,10 +43,15 @@ Usage: pecrant <command>
 
 ![](./images/pecrant_halt.gif)
 
+#### Advance
 
 Support `Select Multiple Lines`:
 
 ![](./images/pecrant_multiple.gif)
+
+Alternative of `pecrant cd`
+
+    $ cd $(pecrant list)
 
 License
 --------------------

--- a/pecrant
+++ b/pecrant
@@ -23,7 +23,7 @@
     }
 
     _pecrant_list() {
-        _pecrant
+        _pecrant | awk '{print $5}'
     }
 
     _pecrant_ssh() {
@@ -60,7 +60,7 @@ Usage: pecrant <command>
   up      Start the selected vagrant machine
   halt    Stop the selected vagrant machine
   ssh     Connect to machine via SSH
-  list    Show vagrant environments for this user
+  list    Show vagrant environments for this user (and output directory)
   help    Show this message
 EOF
     }


### PR DESCRIPTION
Refs:
- [bash - How to run 'cd' in shell script and stay there after script finishes? - Stack Overflow](http://stackoverflow.com/questions/3879431/how-to-run-cd-in-shell-script-and-stay-there-after-script-finishes)

Usage:

```
$ cd $(pecrant list)
```
