### PR TITLE
Add `pecrant dir` instead of `pecrant list`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Usage: pecrant <command>
   up      Start the selected vagrant machine
   halt    Stop the selected vagrant machine
   ssh     Connect to machine via SSH
-  list    Show vagrant environments for this user (and output directory)
+  dir     Show directory path for vagrant environments
+  list    Show vagrant environments for this user
   help    Show this message
 ```
 
@@ -51,7 +52,7 @@ Support `Select Multiple Lines`:
 
 Alternative of `pecrant cd`
 
-    $ cd $(pecrant list)
+    $ cd $(pecrant dir)
 
 License
 --------------------

--- a/pecrant
+++ b/pecrant
@@ -23,6 +23,10 @@
     }
 
     _pecrant_list() {
+        _pecrant
+    }
+
+    _pecrant_dir() {
         _pecrant | awk '{print $5}'
     }
 
@@ -60,7 +64,8 @@ Usage: pecrant <command>
   up      Start the selected vagrant machine
   halt    Stop the selected vagrant machine
   ssh     Connect to machine via SSH
-  list    Show vagrant environments for this user (and output directory)
+  dir     Show directory path for vagrant environments
+  list    Show vagrant environments for this user
   help    Show this message
 EOF
     }


### PR DESCRIPTION
refs GH-3

In order to use the pipe, leave "pecrant list" command to output all columns.
